### PR TITLE
prep for promo

### DIFF
--- a/lib/home/shows.dart
+++ b/lib/home/shows.dart
@@ -51,7 +51,7 @@ final ShowList = [
       title: "PAWTUCKET ART GALLERY",
       date: DateTime(2023, 12, 9, 19)),
   Show(
-      url: "https://ci.ovationtix.com/36186/production/1213789?performanceId=11525072/",
+      url: "https://ci.ovationtix.com/36186/production/1213789?performanceId=11525072",
       title: "ALBUM RELEASE SHOW @ REGENT",
       date: DateTime(2024, 10, 12, 20)),
 ];

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -76,7 +76,7 @@ class _MyHomePageState extends State<MyHomePage> {
       theme: ThemeData(
         tabBarTheme: TabBarTheme(
           indicator: const UnderlineTabIndicator(
-            borderSide: BorderSide(color: Colors.transparent),
+            borderSide: BorderSide(color: Colors.black),
           ),
           labelColor: Colors.black,
           labelStyle: TextStyle(
@@ -93,6 +93,7 @@ class _MyHomePageState extends State<MyHomePage> {
       ),
       home: DefaultTabController(
           length: 3,
+          initialIndex: 2, // make album the default page during promo cycle
           child: Scaffold(
             backgroundColor: Colors.white,
             appBar: AppBar(


### PR DESCRIPTION
sorry for another one, the slash in the ticket link apparently hides the "buy ticket" button on mobile, and it seems like we can't direct link to the album page for promo so I just made it the default page for now